### PR TITLE
Initial Implementation of Shadow Routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 aws_iot-*.tar
 
+# Ignore test files
+test/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# AWS_IoT
+
+## v0.1.1
+
+### New Features
+
+* Add default subscriptions temporaily to get around issue with post-connection subscriptions bringing down AWSIoT connection
+* Add shadow request from AWS IoT
+
+## v0.1.0
+
+Initial release

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,13 @@
+import Config
+
+config :aws_iot,
+  cert: System.get_env("AWS_IOT_CERT"),
+  key: System.get_env("AWS_IOT_KEY"),
+  host: System.get_env("AWS_IOT_HOST")
+
+if Mix.env() == :test do
+  config :aws_iot,
+    adapter: AWSIoTTest.Adapter,
+    host: "localhost",
+    client_id: "foo"
+end

--- a/lib/aws_iot.ex
+++ b/lib/aws_iot.ex
@@ -14,4 +14,9 @@ defmodule AWSIoT do
 
   defdelegate connected?(), to: AWSIoT.Adapter
   defdelegate publish(topic, payload, opts), to: AWSIoT.Adapter
+
+  def topic(:shadow_update, client_id), do: "$aws/things/#{client_id}/shadow/update"
+  def topic(:shadow_get, client_id), do: "$aws/things/#{client_id}/shadow/get"
+  def topic(:shadow_get_accepted, client_id), do: "$aws/things/#{client_id}/shadow/get/accepted"
+  def topic(:shadow_get_rejected, client_id), do: "$aws/things/#{client_id}/shadow/get/rejected"
 end

--- a/lib/aws_iot.ex
+++ b/lib/aws_iot.ex
@@ -14,9 +14,4 @@ defmodule AWSIoT do
 
   defdelegate connected?(), to: AWSIoT.Adapter
   defdelegate publish(topic, payload, opts), to: AWSIoT.Adapter
-
-  def topic(:shadow_update, client_id), do: "$aws/things/#{client_id}/shadow/update"
-  def topic(:shadow_get, client_id), do: "$aws/things/#{client_id}/shadow/get"
-  def topic(:shadow_get_accepted, client_id), do: "$aws/things/#{client_id}/shadow/get/accepted"
-  def topic(:shadow_get_rejected, client_id), do: "$aws/things/#{client_id}/shadow/get/rejected"
 end

--- a/lib/aws_iot/adapter.ex
+++ b/lib/aws_iot/adapter.ex
@@ -134,9 +134,9 @@ defmodule AWSIoT.Adapter do
     |> Keyword.put_new(:subscriptions, [
       {"$aws/things/#{opts[:client_id]}/shadow/get/accepted", 1},
       {"$aws/things/#{opts[:client_id]}/shadow/get/rejected", 1},
-      {"$aws/things/#{opts[:client_id]}/shadow/update", 1},
       {"$aws/things/#{opts[:client_id]}/shadow/get", 1},
-      {"$aws/things/#{opts[:client_id]}/shadow/update/accepted", 1}
+      {"$aws/things/#{opts[:client_id]}/shadow/update/accepted", 1},
+      {"$aws/things/#{opts[:client_id]}/shadow/update/rejected", 1}
     ])
   end
 

--- a/lib/aws_iot/adapter.ex
+++ b/lib/aws_iot/adapter.ex
@@ -5,11 +5,17 @@ defmodule AWSIoT.Adapter do
 
   @callback init(term) :: {:ok, any} | {:error, any}
   @callback connected?(adapter_state :: any) :: boolean
-  @callback publish(topic :: String.t, payload :: String.t, opts :: keyword, adapter_state :: any) :: :ok | {:error, any}
+  @callback publish(
+              topic :: String.t(),
+              payload :: String.t(),
+              opts :: keyword,
+              adapter_state :: any
+            ) :: :ok | {:error, any}
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
+
   def connected?() do
     GenServer.call(__MODULE__, :connected?)
   end
@@ -40,14 +46,19 @@ defmodule AWSIoT.Adapter do
   end
 
   def default_opts(opts) do
-    opts[:host] || raise """
-    AWS IoT requires a :host. You can find this information in the AWS console.
-    """
-    client_id = opts[:client_id] || raise """
-    AWS IoT requires a client id to be set to the same value as the serial number.
-    """
+    opts[:host] ||
+      raise """
+      AWS IoT requires a :host. You can find this information in the AWS console.
+      """
+
+    client_id =
+      opts[:client_id] ||
+        raise """
+        AWS IoT requires a client id to be set to the same value as the serial number.
+        """
 
     signer = Keyword.get(opts, :signer_cert, [])
+
     opts
     |> Keyword.put_new(:port, 443)
     |> Keyword.put_new(:server_name_indication, '*.iot.us-east-1.amazonaws.com')

--- a/lib/aws_iot/adapter.ex
+++ b/lib/aws_iot/adapter.ex
@@ -19,7 +19,6 @@ defmodule AWSIoT.Adapter do
               {:ok, state :: any} | {{:error, any}, state :: any}
 
   def start_link(opts) do
-
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
@@ -42,6 +41,7 @@ defmodule AWSIoT.Adapter do
   def client_id() do
     GenServer.call(__MODULE__, :client_id)
   end
+
   def default_subscriptions() do
     GenServer.call(__MODULE__, :default_subs)
   end
@@ -83,16 +83,22 @@ defmodule AWSIoT.Adapter do
   end
 
   def handle_call({:subscribe, topic, opts}, _from, s) do
-    {reply , adapter_state} = {:ok, s.adapter_state}
+    {reply, adapter_state} = {:ok, s.adapter_state}
     Logger.info("[adapter] :subscribe #{inspect(s.default_subs)} ")
+
     present =
-      Enum.any?(s.default_subs, fn ({default_topic, _}) ->
-        Logger.info("[adapter] :subscribe #{inspect(default_topic)} looking for #{inspect(topic)} ")
+      Enum.any?(s.default_subs, fn {default_topic, _} ->
+        Logger.info(
+          "[adapter] :subscribe #{inspect(default_topic)} looking for #{inspect(topic)} "
+        )
+
         case default_topic do
           ^topic ->
             Logger.info("[adapter] :subscribe  #{inspect(topic)} is present")
             true
-          _ -> false
+
+          _ ->
+            false
         end
       end)
 
@@ -141,7 +147,6 @@ defmodule AWSIoT.Adapter do
       {"$aws/things/U737258/shadow/get/rejected", 1},
       {"$aws/things/U737258/shadow/update", 1},
       {"$aws/things/U737258/shadow/get", 1}
-
     ])
   end
 

--- a/lib/aws_iot/adapters/tortoise.ex
+++ b/lib/aws_iot/adapters/tortoise.ex
@@ -40,7 +40,6 @@ defmodule AWSIoT.Adapters.Tortoise do
 
   def publish(topic, payload, opts, client_id) do
     opts = if opts == [], do: [qos: 0], else: opts
-    Logger.info("publishing to #{inspect(topic)}")
     Tortoise.publish_sync(client_id, topic, payload, opts)
   end
 

--- a/lib/aws_iot/adapters/tortoise.ex
+++ b/lib/aws_iot/adapters/tortoise.ex
@@ -37,4 +37,13 @@ defmodule AWSIoT.Adapters.Tortoise do
     opts = if opts == [], do: [qos: 0], else: opts
     Tortoise.publish_sync(client_id, topic, payload, opts)
   end
+
+  def subscribe(topic, opts, client_id) do
+    opts = if opts == [], do: [qos: 0], else: opts
+    Tortoise.Connection.subscribe(client_id, [topic], opts)
+  end
+
+  def unsubscribe(topic, opts, client_id) do
+    Tortoise.Connection.unsubscribe(client_id, [topic], opts)
+  end
 end

--- a/lib/aws_iot/adapters/tortoise.ex
+++ b/lib/aws_iot/adapters/tortoise.ex
@@ -10,7 +10,7 @@ defmodule AWSIoT.Adapters.Tortoise do
       server: {
         Tortoise.Transport.SSL,
         alpn_advertised_protocols: ["x-amzn-mqtt-ca"],
-        cacerts: (opts[:cacerts]),
+        cacerts: opts[:cacerts],
         cert: opts[:cert],
         host: opts[:host],
         key: opts[:key],
@@ -22,6 +22,7 @@ defmodule AWSIoT.Adapters.Tortoise do
       },
       subscriptions: opts[:subscriptions]
     )
+
     {:ok, client_id}
   end
 
@@ -34,6 +35,6 @@ defmodule AWSIoT.Adapters.Tortoise do
 
   def publish(topic, payload, opts, client_id) do
     opts = if opts == [], do: [qos: 0], else: opts
-    Tortoise.publish_sync(client_id,  topic,  payload, opts)
+    Tortoise.publish_sync(client_id, topic, payload, opts)
   end
 end

--- a/lib/aws_iot/adapters/tortoise.ex
+++ b/lib/aws_iot/adapters/tortoise.ex
@@ -11,7 +11,7 @@ defmodule AWSIoT.Adapters.Tortoise do
       server: {
         Tortoise.Transport.SSL,
         alpn_advertised_protocols: ["x-amzn-mqtt-ca"],
-        cacerts: (opts[:cacerts]),
+        cacerts: opts[:cacerts],
         cert: opts[:cert],
         host: opts[:host],
         key: opts[:key],
@@ -28,10 +28,10 @@ defmodule AWSIoT.Adapters.Tortoise do
   end
 
   def connected?(client_id) do
-
     case Tortoise.Connection.ping_sync(client_id, 5_000) do
       {:ok, _ref} ->
         true
+
       {:error, error} ->
         Logger.info("connected #{inspect(error)}")
         false

--- a/lib/aws_iot/adapters/tortoise.ex
+++ b/lib/aws_iot/adapters/tortoise.ex
@@ -1,4 +1,5 @@
 defmodule AWSIoT.Adapters.Tortoise do
+  require Logger
   @behaviour AWSIoT.Adapter
 
   def init(opts) do
@@ -10,7 +11,7 @@ defmodule AWSIoT.Adapters.Tortoise do
       server: {
         Tortoise.Transport.SSL,
         alpn_advertised_protocols: ["x-amzn-mqtt-ca"],
-        cacerts: opts[:cacerts],
+        cacerts: (opts[:cacerts]),
         cert: opts[:cert],
         host: opts[:host],
         key: opts[:key],
@@ -27,20 +28,26 @@ defmodule AWSIoT.Adapters.Tortoise do
   end
 
   def connected?(client_id) do
+
     case Tortoise.Connection.ping_sync(client_id, 5_000) do
-      {:ok, _ref} -> true
-      {:error, _error} -> false
+      {:ok, _ref} ->
+        true
+      {:error, error} ->
+        Logger.info("connected #{inspect(error)}")
+        false
     end
   end
 
   def publish(topic, payload, opts, client_id) do
     opts = if opts == [], do: [qos: 0], else: opts
+    Logger.info("publishing to #{inspect(topic)}")
     Tortoise.publish_sync(client_id, topic, payload, opts)
   end
 
   def subscribe(topic, opts, client_id) do
     opts = if opts == [], do: [qos: 0], else: opts
-    Tortoise.Connection.subscribe(client_id, [topic], opts)
+    Logger.info("Subscribing #{inspect(topic)}")
+    Tortoise.Connection.subscribe(client_id, topic, opts)
   end
 
   def unsubscribe(topic, opts, client_id) do

--- a/lib/aws_iot/adapters/tortoise_handler.ex
+++ b/lib/aws_iot/adapters/tortoise_handler.ex
@@ -18,12 +18,13 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     {:ok, state}
   end
 
-  def handle_message(topic, payload, state) do
+  def handle_message(topic, payload, state) when is_list(topic) do
     # unhandled message! You will crash if you subscribe to something
     # and you don't have a 'catch all' matcher; crashing on unexpected
     # messages could be a strategy though.
-    Logger.debug("[handler] handle_message: #{inspect(payload)} #{inspect(state) }")
-    send(Router, {:message, topic, payload})
+
+    Logger.debug("[handler] handle_message: payload: #{inspect(payload)} topic: #{inspect(topic)} state: #{inspect(state) }")
+    send(Router, {:message, Enum.join(topic,"/"), payload})
     {:ok, state}
   end
 

--- a/lib/aws_iot/adapters/tortoise_handler.ex
+++ b/lib/aws_iot/adapters/tortoise_handler.ex
@@ -23,21 +23,11 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # and you don't have a 'catch all' matcher; crashing on unexpected
     # messages could be a strategy though.
 
-    Logger.debug(
-      "[handler] handle_message: payload: #{inspect(payload)} topic: #{inspect(topic)} state: #{
-        inspect(state)
-      }"
-    )
-
     send(Router, {:message, Enum.join(topic, "/"), payload})
     {:ok, state}
   end
 
   def subscription(status, topic_filter, state) do
-    Logger.debug(
-      "[handler] subscription: #{inspect(status)} #{inspect(topic_filter)} #{inspect(state)}"
-    )
-
     {:ok, state}
   end
 

--- a/lib/aws_iot/adapters/tortoise_handler.ex
+++ b/lib/aws_iot/adapters/tortoise_handler.ex
@@ -1,6 +1,7 @@
 defmodule AWSIoT.Adapters.Tortoise.Handler do
   use Tortoise.Handler
-
+  alias AWSIoT.Adapter
+  alias AWSIoT.Router
   require Logger
 
   def init(args) do
@@ -12,6 +13,7 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # inform the rest of your system if the connection is currently
     # open or closed; tortoise should be busy reconnecting if you get
     # a `:down`
+    Logger.debug("[hander] Connection: #{inspect(status)}")
     send(Adapter, {:connection_status, status})
     {:ok, state}
   end
@@ -20,11 +22,13 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # unhandled message! You will crash if you subscribe to something
     # and you don't have a 'catch all' matcher; crashing on unexpected
     # messages could be a strategy though.
+    Logger.debug("[handler] handle_message: #{inspect(payload)} #{inspect(state) }")
     send(Router, {:message, topic, payload})
     {:ok, state}
   end
 
-  def subscription(_status, _topic_filter, state) do
+  def subscription(status, topic_filter, state) do
+    Logger.debug("[handler] subscription: #{inspect(status)} #{inspect(topic_filter)} #{inspect(state)}")
     {:ok, state}
   end
 
@@ -32,6 +36,7 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # tortoise doesn't care about what you return from terminate/2,
     # that is in alignment with other behaviours that implement a
     # terminate-callback
+    Logger.debug("[handler] terminate")
     send(Router, {:connection_status, :terminated})
     :ok
   end

--- a/lib/aws_iot/adapters/tortoise_handler.ex
+++ b/lib/aws_iot/adapters/tortoise_handler.ex
@@ -12,14 +12,15 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # inform the rest of your system if the connection is currently
     # open or closed; tortoise should be busy reconnecting if you get
     # a `:down`
-    Logger.debug("[AWS] Connection: #{inspect(status)}")
+    send(Adapter, {:connection_status, status})
     {:ok, state}
   end
 
-  def handle_message(_topic, _payload, state) do
+  def handle_message(topic, payload, state) do
     # unhandled message! You will crash if you subscribe to something
     # and you don't have a 'catch all' matcher; crashing on unexpected
     # messages could be a strategy though.
+    send(Router, {:message, topic, payload})
     {:ok, state}
   end
 
@@ -31,7 +32,7 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # tortoise doesn't care about what you return from terminate/2,
     # that is in alignment with other behaviours that implement a
     # terminate-callback
-    Logger.debug("[AWS] Connection: terminated")
+    send(Router, {:connection_status, :terminated})
     :ok
   end
 end

--- a/lib/aws_iot/adapters/tortoise_handler.ex
+++ b/lib/aws_iot/adapters/tortoise_handler.ex
@@ -12,7 +12,7 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # inform the rest of your system if the connection is currently
     # open or closed; tortoise should be busy reconnecting if you get
     # a `:down`
-    Logger.debug "[AWS] Connection: #{inspect status}"
+    Logger.debug("[AWS] Connection: #{inspect(status)}")
     {:ok, state}
   end
 
@@ -31,7 +31,7 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # tortoise doesn't care about what you return from terminate/2,
     # that is in alignment with other behaviours that implement a
     # terminate-callback
-    Logger.debug "[AWS] Connection: terminated"
+    Logger.debug("[AWS] Connection: terminated")
     :ok
   end
 end

--- a/lib/aws_iot/adapters/tortoise_handler.ex
+++ b/lib/aws_iot/adapters/tortoise_handler.ex
@@ -23,13 +23,21 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # and you don't have a 'catch all' matcher; crashing on unexpected
     # messages could be a strategy though.
 
-    Logger.debug("[handler] handle_message: payload: #{inspect(payload)} topic: #{inspect(topic)} state: #{inspect(state) }")
-    send(Router, {:message, Enum.join(topic,"/"), payload})
+    Logger.debug(
+      "[handler] handle_message: payload: #{inspect(payload)} topic: #{inspect(topic)} state: #{
+        inspect(state)
+      }"
+    )
+
+    send(Router, {:message, Enum.join(topic, "/"), payload})
     {:ok, state}
   end
 
   def subscription(status, topic_filter, state) do
-    Logger.debug("[handler] subscription: #{inspect(status)} #{inspect(topic_filter)} #{inspect(state)}")
+    Logger.debug(
+      "[handler] subscription: #{inspect(status)} #{inspect(topic_filter)} #{inspect(state)}"
+    )
+
     {:ok, state}
   end
 

--- a/lib/aws_iot/adapters/tortoise_handler.ex
+++ b/lib/aws_iot/adapters/tortoise_handler.ex
@@ -13,7 +13,7 @@ defmodule AWSIoT.Adapters.Tortoise.Handler do
     # inform the rest of your system if the connection is currently
     # open or closed; tortoise should be busy reconnecting if you get
     # a `:down`
-    Logger.debug("[hander] Connection: #{inspect(status)}")
+    Logger.debug("[handler] Connection: #{inspect(status)}")
     send(Adapter, {:connection_status, status})
     {:ok, state}
   end

--- a/lib/aws_iot/application.ex
+++ b/lib/aws_iot/application.ex
@@ -11,6 +11,7 @@ defmodule AWSIoT.Application do
     shadow_opts =
       Application.get_env(:aws_iot, :shadow, [])
       |> Keyword.put(:name, AWSIoT.Shadow)
+      |> Keyword.put(:path, "/root/")
 
     children = [
       # Starts a worker by calling: AWSIoT.Worker.start_link(arg)

--- a/lib/aws_iot/application.ex
+++ b/lib/aws_iot/application.ex
@@ -7,9 +7,15 @@ defmodule AWSIoT.Application do
 
   def start(_type, _args) do
     opts = Application.get_all_env(:aws_iot)
+
+    shadow_opts =
+      Application.get_env(:aws_iot, :shadow, [])
+      |> Keyword.put(:name, AWSIoT.Shadow)
+
     children = [
       # Starts a worker by calling: AWSIoT.Worker.start_link(arg)
-      {AWSIoT.Adapter, opts}
+      {AWSIoT.Adapter, opts},
+      {AWSIoT.Shadow, shadow_opts}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/aws_iot/application.ex
+++ b/lib/aws_iot/application.ex
@@ -14,6 +14,7 @@ defmodule AWSIoT.Application do
 
     children = [
       # Starts a worker by calling: AWSIoT.Worker.start_link(arg)
+      AWSIoT.Router,
       {AWSIoT.Adapter, opts},
       {AWSIoT.Shadow, shadow_opts}
     ]

--- a/lib/aws_iot/router.ex
+++ b/lib/aws_iot/router.ex
@@ -1,0 +1,79 @@
+defmodule AWSIoT.Router do
+  use GenServer
+
+  alias AWSIoT.Adapter
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def subscribe(topic) do
+    GenServer.call(__MODULE__, {:subscribe, topic})
+  end
+
+  def unsubscribe(topic) do
+    GenServer.call(__MODULE__, {:subscribe, topic})
+  end
+
+  def init(_opts) do
+    {:ok,
+     %{
+       subscribers: []
+     }}
+  end
+
+  def handle_call({:subscribe, topic}, {pid, _ref}, s) do
+    subscribers =
+      case Enum.member?(s.subscribers, {pid, topic}) do
+        true ->
+          s.subscribers
+
+        false ->
+          Adapter.subscribe(topic)
+          mon_ref = Process.monitor(pid)
+          [{pid, mon_ref, topic} | s.subscribers]
+      end
+
+    {:reply, :ok, %{s | subscribers: subscribers}}
+  end
+
+  def handle_info({:message, topic, payload}, s) do
+    broadcast_messages(topic, payload, s.subscribers)
+    {:noreply, s}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, s) do
+    {down, subscribers} =
+      Enum.split_with(s.subscribers, fn {_, p_ref, _} ->
+        p_ref == ref
+      end)
+
+    case down do
+      [] ->
+        :noop
+
+      [{_, _, topic}] ->
+        cleanup_subscriptions(topic, subscribers)
+    end
+
+    {:noreply, %{s | subscribers: subscribers}}
+  end
+
+  defp broadcast_messages(topic, payload, subscribers) do
+    Enum.each(subscribers, fn
+      {pid, _, ^topic} ->
+        send(pid, {:aws_iot, topic, payload})
+
+      _ ->
+        :noop
+    end)
+  end
+
+  defp cleanup_subscriptions(topic, subscribers) do
+    retain? = Enum.any?(subscribers, fn {_, _, s_topic} -> s_topic == topic end)
+
+    unless retain? do
+      Adapter.unsubscribe(topic)
+    end
+  end
+end

--- a/lib/aws_iot/router.ex
+++ b/lib/aws_iot/router.ex
@@ -72,8 +72,10 @@ defmodule AWSIoT.Router do
   end
 
   defp broadcast_messages(topic, payload, subscribers) do
+    Logger.debug("[#{inspect(__MODULE__)}] broadcast topic #{inspect(topic)} subscribers#{inspect(subscribers)}")
     Enum.each(subscribers, fn
       {pid, _, ^topic} ->
+        Logger.debug("[#{inspect(__MODULE__)}] broadcast to #{inspect(pid)}")
         send(pid, {:aws_iot, topic, payload})
 
       _ ->

--- a/lib/aws_iot/router.ex
+++ b/lib/aws_iot/router.ex
@@ -1,6 +1,6 @@
 defmodule AWSIoT.Router do
   use GenServer
-
+  require Logger
   alias AWSIoT.Adapter
 
   def start_link(opts) do
@@ -23,16 +23,28 @@ defmodule AWSIoT.Router do
   end
 
   def handle_call({:subscribe, topic}, {pid, _ref}, s) do
-    subscribers =
-      case Enum.member?(s.subscribers, {pid, topic}) do
-        true ->
-          s.subscribers
 
-        false ->
-          Adapter.subscribe(topic)
-          mon_ref = Process.monitor(pid)
-          [{pid, mon_ref, topic} | s.subscribers]
-      end
+    Logger.info("[router] :subscribe #{inspect(s.subscribers)} ")
+    subscribers =
+    case Enum.any?(s.subscribers, fn subscriber ->
+            case subscriber do
+              {^pid, _, ^topic} ->
+                Logger.info("[router] :subscribe mon_ref#{inspect(subscriber)} ")
+                true
+              _ ->
+                false
+            end
+          end) do
+      true ->
+        s.subscribers
+      false ->
+        mon_ref = Process.monitor(pid)
+        Logger.info("[router] :subscribe mon_ref#{inspect(mon_ref)} ")
+        Adapter.subscribe(topic)
+        [{pid, mon_ref, topic} | s.subscribers]
+    end
+
+    Logger.info("[router] :subscribe #{inspect(pid)} #{inspect(subscribers)} ")
 
     {:reply, :ok, %{s | subscribers: subscribers}}
   end
@@ -75,5 +87,23 @@ defmodule AWSIoT.Router do
     unless retain? do
       Adapter.unsubscribe(topic)
     end
+  end
+
+  def get_subscriber_list(adapter_state, pid, topic) do
+    subscribers =
+      case Enum.any?(adapter_state.subscribers, fn subscriber ->
+             case subscriber do
+               {^pid, _, ^topic} -> true
+               _ -> false
+             end
+            end) do
+        true ->
+          adapter_state.subscribers
+
+        false ->
+          mon_ref = Process.monitor(pid)
+          Adapter.subscribe(pid)
+          [{pid, mon_ref, topic} | adapter_state.subscribers]
+      end
   end
 end

--- a/lib/aws_iot/shadow.ex
+++ b/lib/aws_iot/shadow.ex
@@ -84,14 +84,22 @@ defmodule AWSIoT.Shadow do
   end
 
   def handle_info({:aws_iot, topic, payload}, s) do
+    Logger.debug("[shadow] aws_iot topic:#{inspect(topic)} payload:#{inspect(payload)} ")
     [_, command] = String.split(topic, "shadow/", parts: 2)
+    Logger.debug("[#{inspect(__MODULE__)}] aws_iot command:#{inspect(command)} payload:#{inspect(payload)} ")
     handle_upstream(command, payload, s)
   end
 
-  def handle_upstream("update", payload, s) do
+  def handle_upstream("get/accepted", payload, s) do
     shadow = Jason.decode!(payload)
     write_shadow(s.file, shadow)
+    Logger.debug("[#{inspect(__MODULE__)}] handle_upstream shadow:#{inspect(shadow)} ")
     {:noreply, %{s | shadow: shadow}}
+  end
+
+  def handle_upstream("get", payload, s) do
+    :noop
+    {:noreply, s }
   end
 
   defp read_shadow(file) do

--- a/lib/aws_iot/shadow.ex
+++ b/lib/aws_iot/shadow.ex
@@ -1,0 +1,80 @@
+defmodule AWSIoT.Shadow do
+  use GenServer
+
+  @shadow_filename "aws_iot_shadow.json"
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, genserver_opts(opts))
+  end
+
+  def get_shadow(pid \\ __MODULE__) do
+    GenServer.call(pid, :get_shadow)
+  end
+
+  def update_shadow(pid \\ __MODULE__, fun) do
+    GenServer.call(pid, {:update_shadow, fun})
+  end
+
+  def genserver_opts(opts) do
+    case Keyword.fetch(opts, :name) do
+      {:ok, name} -> [name: name]
+      _ -> []
+    end
+  end
+
+  def init(opts) do
+    filename = opts[:shadow_filename] || @shadow_filename
+    shadow_file = Path.join(path(opts[:shadow_path]), filename)
+
+    {:ok,
+     %{
+       shadow_file: shadow_file,
+       shadow: nil
+     }, {:continue, File.exists?(shadow_file)}}
+  end
+
+  def handle_continue(true, %{shadow_file: file} = s) do
+    {:noreply, %{s | shadow: read_shadow(file)}}
+  end
+
+  def handle_continue(false, %{shadow_file: file} = s) do
+    dirname = Path.dirname(file)
+
+    with :ok <- File.mkdir_p(dirname),
+         :ok <- write_shadow(file, "") do
+      {:noreply, %{s | shadow: ""}}
+    else
+      _ ->
+        {:noreply, %{s | shadow_file: nil}}
+    end
+  end
+
+  def handle_call(:get_shadow, _from, %{shadow: shadow} = s) do
+    {:reply, shadow, s}
+  end
+
+  def handle_call({:update_shadow, fun}, _from, %{shadow: shadow, shadow_file: file} = s) do
+    shadow = fun.(shadow)
+    write_shadow(file, shadow)
+    {:reply, :ok, %{s | shadow: shadow}}
+  end
+
+  defp read_shadow(file) do
+    with {:ok, data} <- File.read(file) do
+      :erlang.binary_to_term(data)
+    else
+      _ ->
+        %{}
+    end
+  end
+
+  defp write_shadow(nil, _shadow), do: {:error, :no_file}
+
+  defp write_shadow(file, shadow) do
+    data = :erlang.term_to_binary(shadow)
+    File.write(file, data, [:write, :sync])
+  end
+
+  defp path(nil), do: System.tmp_dir!()
+  defp path(path), do: Path.expand(path)
+end

--- a/lib/aws_iot/shadow.ex
+++ b/lib/aws_iot/shadow.ex
@@ -68,7 +68,7 @@ defmodule AWSIoT.Shadow do
     {:reply, shadow, s}
   end
 
-  def handle_call(:request_upstream, s) do
+  def handle_call(:request_upstream, _from, s) do
     subscribe()
     client_id = Adapter.client_id()
     topic = "$aws/things/#{client_id}/shadow/get"

--- a/lib/aws_iot/ssl.ex
+++ b/lib/aws_iot/ssl.ex
@@ -5,6 +5,7 @@ defmodule AWSIoT.SSL do
     Enum.reduce_while(AWSIoT.cacerts(), :unknown_ca, fn aws_root_ca, unk_ca ->
       certificate = aws_root_ca |> Certificate.from_der!()
       certificate_subject = Certificate.extension(certificate, :subject_key_identifier)
+
       case find_partial_chain(certificate_subject, server_certs) do
         {:trusted_ca, _} = result -> {:halt, result}
         :unknown_ca -> {:cont, unk_ca}
@@ -20,6 +21,7 @@ defmodule AWSIoT.SSL do
     cert = Certificate.from_der!(h)
     cert_ski = Certificate.extension(cert, :subject_key_identifier)
     cert_aki = Certificate.extension(cert, :ancestor_key_identifier)
+
     if root_subject in [cert_ski, cert_aki] do
       {:trusted_ca, h}
     else

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule AWSIoT.MixProject do
       version: "0.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps()
     ]
   end
@@ -18,6 +19,9 @@ defmodule AWSIoT.MixProject do
       mod: {AWSIoT.Application, []}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AWSIoT.MixProject do
   def project do
     [
       app: :aws_iot,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule AWSIoT.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:jason, "~> 1.0"},
       {:tortoise, "~> 0.9"},
       {:x509, "~> 0.8"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
-  "gen_state_machine": {:hex, :gen_state_machine, "2.0.5", "9ac15ec6e66acac994cc442dcc2c6f9796cf380ec4b08267223014be1c728a95", [:mix], [], "hexpm"},
-  "tortoise": {:hex, :tortoise, "0.9.4", "3bca5f4475f80a5bd45aab644ddb3364dd0956b67f4202dcef6ed20e045ea3a6", [:mix], [{:gen_state_machine, "~> 2.0", [hex: :gen_state_machine, repo: "hexpm", optional: false]}], "hexpm"},
-  "x509": {:hex, :x509, "0.8.0", "b286b9dbb32801f76f48bdea476304d280c64ce172ea330c23d8df7ea9e75ce6", [:mix], [], "hexpm"},
+  "gen_state_machine": {:hex, :gen_state_machine, "2.0.5", "9ac15ec6e66acac994cc442dcc2c6f9796cf380ec4b08267223014be1c728a95", [:mix], [], "hexpm", "5cacd405e72b2609a7e1f891bddb80c53d0b3b7b0036d1648e7382ca108c41c8"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "tortoise": {:hex, :tortoise, "0.9.4", "3bca5f4475f80a5bd45aab644ddb3364dd0956b67f4202dcef6ed20e045ea3a6", [:mix], [{:gen_state_machine, "~> 2.0", [hex: :gen_state_machine, repo: "hexpm", optional: false]}], "hexpm", "d5c00d7c2329016376181e19f18116a10fc65691bd96b08e5b726ca050d10094"},
+  "x509": {:hex, :x509, "0.8.0", "b286b9dbb32801f76f48bdea476304d280c64ce172ea330c23d8df7ea9e75ce6", [:mix], [], "hexpm", "8aafaafdcafb1ea9f06bfc32c3b03ccc66f087e0faf36ef94c0195bb7a04157e"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "gen_state_machine": {:hex, :gen_state_machine, "2.0.5", "9ac15ec6e66acac994cc442dcc2c6f9796cf380ec4b08267223014be1c728a95", [:mix], [], "hexpm", "5cacd405e72b2609a7e1f891bddb80c53d0b3b7b0036d1648e7382ca108c41c8"},
+  "gen_state_machine": {:hex, :gen_state_machine, "2.1.0", "a38b0e53fad812d29ec149f0d354da5d1bc0d7222c3711f3a0bd5aa608b42992", [:mix], [], "hexpm", "ae367038808db25cee2f2c4b8d0531522ea587c4995eb6f96ee73410a60fa06b"},
   "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
   "tortoise": {:hex, :tortoise, "0.9.4", "3bca5f4475f80a5bd45aab644ddb3364dd0956b67f4202dcef6ed20e045ea3a6", [:mix], [{:gen_state_machine, "~> 2.0", [hex: :gen_state_machine, repo: "hexpm", optional: false]}], "hexpm", "d5c00d7c2329016376181e19f18116a10fc65691bd96b08e5b726ca050d10094"},
-  "x509": {:hex, :x509, "0.8.0", "b286b9dbb32801f76f48bdea476304d280c64ce172ea330c23d8df7ea9e75ce6", [:mix], [], "hexpm", "8aafaafdcafb1ea9f06bfc32c3b03ccc66f087e0faf36ef94c0195bb7a04157e"},
+  "x509": {:hex, :x509, "0.8.1", "901a72cb715aeb2f21739425cc0cff97ce975b6267811acb1fcee4ff10e7799c", [:mix], [], "hexpm", "30c6d9376c90c74490c80befea53cc0d07f05d48bb4ce9e472573a06b0aae008"},
 }

--- a/test/aws_iot/shadow_test.exs
+++ b/test/aws_iot/shadow_test.exs
@@ -4,6 +4,87 @@ defmodule AWSIoT.ShadowTest do
   alias AWSIoT.Shadow
 
   @client_id Application.get_env(:aws_iot, :client_id)
+  @shadow_sample = %{
+    "metadata" => %{
+      "desired" => %{
+        "requested_tags" => [
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906},
+          %{"timestamp" => 1_589_913_906}
+        ],
+        "welcome" => %{"timestamp" => 1_589_913_906}
+      },
+      "reported" => %{"welcome" => %{"timestamp" => 1_589_913_906}}
+    },
+    "state" => %{
+      "delta" => %{
+        "requested_tags" => [
+          "Machine_Run_Not_Jog",
+          "JAM_LATCH",
+          "ANVIL_THICKNESS",
+          "ANVIL_KNIFE_DEPTH",
+          "GRIND_ENABLED_ONS",
+          "FIND_CVR_START",
+          "GRIND_HMI_OVRD_VALUE",
+          "Single_Feed_Latch",
+          "Board_Count_Total",
+          "MACH_SPD_ACTUAL_RPM_REAL",
+          "P1_INK_BOOL_ARRAY0_4",
+          "P1_INK_BOOL_ARRAY0_8",
+          "All_EStops_OK_to_Run",
+          "ANVIL_COMP_ConverterOutputCurrent",
+          "P1_HMI_INK_DINT_ARRAY3",
+          "FEED_REQUEST_SEALED",
+          "FE_GUIDE_REAL_ARRAY_OS",
+          "FE_GUIDE_REAL_ARRAY_DS",
+          "Sunset_Current_Feed_BackStop_Target"
+        ]
+      },
+      "desired" => %{
+        "requested_tags" => [
+          "Machine_Run_Not_Jog",
+          "JAM_LATCH",
+          "ANVIL_THICKNESS",
+          "ANVIL_KNIFE_DEPTH",
+          "GRIND_ENABLED_ONS",
+          "FIND_CVR_START",
+          "GRIND_HMI_OVRD_VALUE",
+          "Single_Feed_Latch",
+          "Board_Count_Total",
+          "MACH_SPD_ACTUAL_RPM_REAL",
+          "P1_INK_BOOL_ARRAY0_4",
+          "P1_INK_BOOL_ARRAY0_8",
+          "All_EStops_OK_to_Run",
+          "ANVIL_COMP_ConverterOutputCurrent",
+          "P1_HMI_INK_DINT_ARRAY3",
+          "FEED_REQUEST_SEALED",
+          "FE_GUIDE_REAL_ARRAY_OS",
+          "FE_GUIDE_REAL_ARRAY_DS",
+          "Sunset_Current_Feed_BackStop_Target"
+        ],
+        "welcome" => "aws-iot"
+      },
+      "reported" => %{"welcome" => "aws-iot"}
+    },
+    "timestamp" => 1_590_002_257,
+    "version" => 32
+  }
 
   setup context do
     path = Path.join([File.cwd!(), "test", "tmp", "shadow"])
@@ -40,6 +121,9 @@ defmodule AWSIoT.ShadowTest do
     end)
 
     assert %{"foo" => "bar"} = Shadow.get_shadow(pid)
+  end
+
+  test "decode shadow object", %{pid: pid} do
   end
 
   test "update from server", %{pid: pid} do

--- a/test/aws_iot/shadow_test.exs
+++ b/test/aws_iot/shadow_test.exs
@@ -1,0 +1,44 @@
+defmodule AWSIoT.ShadowTest do
+  use ExUnit.Case
+  doctest AWSIoT.Shadow
+  alias AWSIoT.Shadow
+
+  setup context do
+    path = Path.join([File.cwd!(), "test", "tmp", "shadow"])
+    filename = to_string(context.test)
+    {:ok, pid} = Shadow.start_link(shadow_filename: filename, shadow_path: path)
+    [pid: pid, shadow_file: Path.join(path, filename)]
+  end
+
+  test "create shadow file", %{pid: pid, shadow_file: file} do
+    Shadow.update_shadow(pid, fn _shadow ->
+      %{foo: :bar}
+    end)
+
+    assert File.exists?(file)
+  end
+
+  test "update shadow", %{pid: pid, shadow_file: file} do
+    Shadow.update_shadow(pid, fn _shadow ->
+      %{foo: :bar}
+    end)
+
+    assert File.exists?(file)
+
+    Shadow.update_shadow(pid, fn shadow ->
+      Map.put(shadow, :baz, :qux)
+    end)
+
+    assert %{foo: :bar, baz: :qux} = Shadow.get_shadow(pid)
+  end
+
+  test "get shadow", %{pid: pid} do
+    assert "" = Shadow.get_shadow(pid)
+
+    Shadow.update_shadow(pid, fn _shadow ->
+      %{foo: :bar}
+    end)
+
+    assert %{foo: :bar} = Shadow.get_shadow(pid)
+  end
+end

--- a/test/aws_iot/shadow_test.exs
+++ b/test/aws_iot/shadow_test.exs
@@ -3,42 +3,48 @@ defmodule AWSIoT.ShadowTest do
   doctest AWSIoT.Shadow
   alias AWSIoT.Shadow
 
+  @client_id Application.get_env(:aws_iot, :client_id)
+
   setup context do
     path = Path.join([File.cwd!(), "test", "tmp", "shadow"])
     filename = to_string(context.test)
-    {:ok, pid} = Shadow.start_link(shadow_filename: filename, shadow_path: path)
+    {:ok, pid} = Shadow.start_link(filename: filename, path: path)
     [pid: pid, shadow_file: Path.join(path, filename)]
   end
 
   test "create shadow file", %{pid: pid, shadow_file: file} do
     Shadow.update_shadow(pid, fn _shadow ->
-      %{foo: :bar}
+      %{"foo" => "bar"}
     end)
 
     assert File.exists?(file)
   end
 
-  test "update shadow", %{pid: pid, shadow_file: file} do
+  test "update shadow", %{pid: pid} do
     Shadow.update_shadow(pid, fn _shadow ->
-      %{foo: :bar}
+      %{"foo" => "bar"}
     end)
-
-    assert File.exists?(file)
 
     Shadow.update_shadow(pid, fn shadow ->
-      Map.put(shadow, :baz, :qux)
+      Map.put(shadow, "baz", "qux")
     end)
 
-    assert %{foo: :bar, baz: :qux} = Shadow.get_shadow(pid)
+    assert %{"foo" => "bar", "baz" => "qux"} = Shadow.get_shadow(pid)
   end
 
   test "get shadow", %{pid: pid} do
     assert "" = Shadow.get_shadow(pid)
 
     Shadow.update_shadow(pid, fn _shadow ->
-      %{foo: :bar}
+      %{"foo" => "bar"}
     end)
 
-    assert %{foo: :bar} = Shadow.get_shadow(pid)
+    assert %{"foo" => "bar"} = Shadow.get_shadow(pid)
+  end
+
+  test "update from server", %{pid: pid} do
+    shadow = %{"foo" => "bar"}
+    send(pid, {:aws_iot, "$aws/things/#{@client_id}/shadow/update", Jason.encode!(shadow)})
+    assert ^shadow = Shadow.get_shadow(pid)
   end
 end

--- a/test/aws_iot_test.exs
+++ b/test/aws_iot_test.exs
@@ -4,15 +4,15 @@ defmodule AWSIoTTest do
 
   alias AWSIoT.Shadow
 
-  test "connected?" do
-    assert AWSIoT.connected?() == false
-    set_connected(true)
-    assert AWSIoT.connected?() == true
-  end
+  # test "connected?" do
+  #   assert AWSIoT.connected?() == false
+  #   set_connected(true)
+  #   assert AWSIoT.connected?() == true
+  # end
 
-  defp set_connected(connected) do
-    :sys.replace_state(AWSIoT.Adapter, fn {mod, state} ->
-      {mod, %{state | connected?: connected}}
-    end)
-  end
+  # defp set_connected(connected) do
+  #   :sys.replace_state(AWSIoT.Adapter, fn {mod, state} ->
+  #     {mod, %{state | connected?: connected}}
+  #   end)
+  # end
 end

--- a/test/aws_iot_test.exs
+++ b/test/aws_iot_test.exs
@@ -2,4 +2,17 @@ defmodule AWSIoTTest do
   use ExUnit.Case
   doctest AWSIoT
 
+  alias AWSIoT.Shadow
+
+  test "connected?" do
+    assert AWSIoT.connected?() == false
+    set_connected(true)
+    assert AWSIoT.connected?() == true
+  end
+
+  defp set_connected(connected) do
+    :sys.replace_state(AWSIoT.Adapter, fn {mod, state} ->
+      {mod, %{state | connected?: connected}}
+    end)
+  end
 end

--- a/test/support/test_adapter.ex
+++ b/test/support/test_adapter.ex
@@ -4,6 +4,7 @@ defmodule AWSIoTTest.Adapter do
   def init(_opts) do
     {:ok,
      %{
+       subscriptions: [],
        connected?: false
      }}
   end
@@ -12,7 +13,16 @@ defmodule AWSIoTTest.Adapter do
     connected?
   end
 
-  def publish(_topic, _payload, _opts, _client_id) do
-    :ok
+  def publish(_topic, _payload, _opts, s) do
+    {:ok, s}
+  end
+
+  def subscribe(topic, _opts, s) do
+    {:ok, %{s | subscriptions: [topic | s.subscriptions]}}
+  end
+
+  def unsubscribe(topic, _opts, s) do
+    {_, subscriptions} = Enum.split_with(s.subscriptions, &(&1 == topic))
+    {:ok, %{s | subscriptions: subscriptions}}
   end
 end

--- a/test/support/test_adapter.ex
+++ b/test/support/test_adapter.ex
@@ -1,0 +1,18 @@
+defmodule AWSIoTTest.Adapter do
+  @behaviour AWSIoT.Adapter
+
+  def init(_opts) do
+    {:ok,
+     %{
+       connected?: false
+     }}
+  end
+
+  def connected?(%{connected?: connected?}) do
+    connected?
+  end
+
+  def publish(_topic, _payload, _opts, _client_id) do
+    :ok
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+File.rm_rf("test/tmp")
+
 ExUnit.start()


### PR DESCRIPTION
Why:
Add initial version of an AWS IoT interaction with the shadow object

How:
* By implementing a router  that takes care of managing subscriptions/notifications to mqtt topics 
* By adding a mechanism to interact with the AWS IoT shadow object while maintaining a single connection to AWSIoT