### PR TITLE
Fix GCP CA cert parsing

### DIFF
--- a/lib/cloud_pub_sub.ex
+++ b/lib/cloud_pub_sub.ex
@@ -16,6 +16,9 @@ defmodule CloudPubSub do
                 |> Stream.map(&Path.join([:code.priv_dir(:cloud_pub_sub), "ca_certs", "gcp", &1]))
                 |> Stream.map(&Path.expand/1)
                 |> Stream.map(&File.read!/1)
+                |> Stream.flat_map(&String.split(&1, "-----END CERTIFICATE-----"))
+                |> Stream.map(&"#{&1}-----END CERTIFICATE-----")
+                |> Enum.slice(0..-2)
                 |> Stream.map(&X509.Certificate.from_pem!/1)
                 |> Enum.map(&X509.Certificate.to_der/1)
 

--- a/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
@@ -14,13 +14,10 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
 
     server_opts = [
       cacerts: opts[:ca_certs],
-      # cert: opts[:device_cert],
       host: opts[:host],
-      # key: opts[:device_key],
       partial_chain: &CloudPubSub.SSL.partial_chain(opts[:cloud_provider], &1),
       port: opts[:port],
-      verify: :verify_none,
-      # verify: :verify_peer,
+      verify: :verify_peer,
       versions: [:"tlsv1.2"]
     ]
 


### PR DESCRIPTION
Why
---

- Only the first cert was being respected.

How
---

- Split the certs before parsing them.