### PR TITLE
Fix TCP adapter connection opts

### DIFF
--- a/lib/cloud_pub_sub/adapters/tortoise/tcp.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise/tcp.ex
@@ -9,7 +9,20 @@ defmodule CloudPubSub.Adapters.Tortoise.TCP do
          host: Keyword.fetch!(opts, :host)
        ]}
 
-    CloudPubSub.Adapters.Tortoise.tortoise_connect(opts[:client_id], opts[:subscriptions], server)
+    connection_opts = %{
+      cloud_provider: opts[:cloud_provider],
+      client_id: opts[:client_id],
+      subscriptions: opts[:subscriptions],
+      server: server
+    }
+
+    connection_opts =
+      case opts[:cloud_provider] do
+        :aws -> connection_opts
+        :gcp -> Map.put(connection_opts, :password, opts[:password])
+      end
+
+    CloudPubSub.Adapters.Tortoise.tortoise_connect(connection_opts)
     {:ok, %{client_id: opts[:client_id]}}
   end
 end


### PR DESCRIPTION
When attempting to use `CloudPubSub.Adapters.Tortoise.TCP` I was receiving the following error:

```
** (UndefinedFunctionError) function CloudPubSub.Adapters.Tortoise.tortoise_connect/3 is undefined or private
```

This PR updates the `TCP.tortoise_connect` function to accept the args using the correct arity. I reused similar code from `CloudPubSub.Adapters.Tortoise.SSL`.