### PR TITLE
Add the ability to specify a subscription handler module

### DIFF
--- a/lib/cloud_pub_sub/adapter.ex
+++ b/lib/cloud_pub_sub/adapter.ex
@@ -80,6 +80,7 @@ defmodule CloudPubSub.Adapter do
   `:client_id` - `String.t()`. Required. The MQTT client ID to connect with.
   `:device_cert` - `String.t()`. Required. The client certificate.
   `:device_key` - `String.t()`. Required. The client key.
+  `:handler` - `module()`. Optional. A subscription handler module.
   `:host` - `String.t()`. Required. The MQTT endpoint to connect to. Typically your ATS endpoint.
   `:port` - `integer()`. Optional. Defaults to `443`. The MQTT port to connect to.
   `:server_name_indication` - `String.t()`. Optional. Defaults to `*.iot.us-east-1.amazonaws.com`.

--- a/lib/cloud_pub_sub/adapters/tortoise.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise.ex
@@ -38,10 +38,11 @@ defmodule CloudPubSub.Adapters.Tortoise do
       end
 
     server = {server_module, server_opts}
+    handler = opts[:handler] || CloudPubSub.Adapters.Tortoise.Handler
 
     connection_opts = [
       client_id: opts.client_id,
-      handler: {CloudPubSub.Adapters.Tortoise.Handler, []},
+      handler: {handler, []},
       server: server,
       subscriptions: opts.subscriptions
     ]

--- a/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
@@ -46,6 +46,7 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
     connection_opts = %{
       cloud_provider: opts[:cloud_provider],
       client_id: opts[:client_id],
+      handler: opts[:handler],
       subscriptions: opts[:subscriptions],
       server: server
     }

--- a/lib/cloud_pub_sub/adapters/tortoise/tcp.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise/tcp.ex
@@ -12,6 +12,7 @@ defmodule CloudPubSub.Adapters.Tortoise.TCP do
     connection_opts = %{
       cloud_provider: opts[:cloud_provider],
       client_id: opts[:client_id],
+      handler: opts[:handler],
       subscriptions: opts[:subscriptions],
       server: server
     }


### PR DESCRIPTION
This PR allows a developer to create their own subscription handler module and pass it to `CloudPubSub`:

```ex
CloudPubSub.Adapter.start_link(handler: MyProject.TortoiseHandler)
```