### PR TITLE
Increase the genserver timeout to be greater than the adapter's ping_…

### DIFF
--- a/lib/cloud_pub_sub/adapter.ex
+++ b/lib/cloud_pub_sub/adapter.ex
@@ -31,7 +31,7 @@ defmodule CloudPubSub.Adapter do
   @doc """
   Return whether there is an active connection to AWS IoT Core.
   """
-  def connected?(), do: GenServer.call(__MODULE__, :connected?)
+  def connected?(), do: GenServer.call(__MODULE__, :connected?, 10_000)
 
   @impl GenServer
   def handle_call(:connected?, _from, state) do


### PR DESCRIPTION
WHY
----
Tortoise doesnt have a chance to timeout during connection check (its timeout is also 5 seconds)

HOW
----
Increase the call's timeout to be greater than the default genserver timeout and the tortoise timeout