### PR TITLE
Fix options resolution for GCP with TLS

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,6 @@
+import Config
+
+if Mix.env() == :dev do
+  config :mix_test_watch,
+    clear: true
+end

--- a/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
@@ -2,49 +2,18 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
   use CloudPubSub.Adapters.Tortoise
 
   def init(opts) do
-    opts =
-      case opts[:cloud_provider] do
-        :aws ->
-          opts[:device_cert] || raise "AWS IoT requires a :device_cert."
-          opts[:device_key] || raise "AWS IoT requires a :device_key."
-          opts[:signer_cert] || raise "AWS IoT requires a :signer_cert."
-          Keyword.put(opts, :ca_certs, [opts[:signer_cert] | opts[:ca_certs]])
+    opts
+    |> resolve_connection_opts()
+    |> CloudPubSub.Adapters.Tortoise.tortoise_connect()
 
-        :gcp ->
-          opts[:password] || raise "GCP requires a :password."
-          opts
-      end
+    {:ok, %{client_id: opts[:client_id]}}
+  end
 
-    server_opts = [
-      cacerts: opts[:ca_certs],
-      host: opts[:host],
-      partial_chain: &CloudPubSub.SSL.partial_chain(opts[:cloud_provider], &1),
-      port: opts[:port],
-      verify: :verify_peer,
-      versions: [:"tlsv1.2"],
-      cert: opts[:device_cert],
-      key: opts[:device_key]
-    ]
-
-    server_opts =
-      case opts[:cloud_provider] do
-        :aws ->
-          Keyword.merge(
-            [
-              server_name_indication: "*.iot.us-east-1.amazonaws.com",
-              alpn_advertised_protocols: ["x-amzn-mqtt-ca"]
-            ],
-            server_opts
-          )
-
-        :gcp ->
-          Keyword.merge(
-            [],
-            server_opts
-          )
-      end
-
-    server = {Tortoise.Transport.SSL, server_opts}
+  @doc """
+  Resolves connection options suitable for `CloudPubSub.Adapters.Tortoise.tortoise_connect/1`.
+  """
+  def resolve_connection_opts(opts) do
+    server = {Tortoise.Transport.SSL, resolve_server_opts(opts)}
 
     connection_opts = %{
       cloud_provider: opts[:cloud_provider],
@@ -54,13 +23,53 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
       server: server
     }
 
-    connection_opts =
-      case opts[:cloud_provider] do
-        :aws -> connection_opts
-        :gcp -> Map.put(connection_opts, :password, opts[:password])
-      end
+    case opts[:cloud_provider] do
+      :aws ->
+        connection_opts
 
-    CloudPubSub.Adapters.Tortoise.tortoise_connect(connection_opts)
-    {:ok, %{client_id: opts[:client_id]}}
+      :gcp ->
+        opts[:password] || raise "GCP requires a :password."
+        Map.merge(connection_opts, %{password: opts[:password]})
+    end
+  end
+
+  defp resolve_server_opts(raw_opts) do
+    opts = default_and_map_and_filter_server_opts(raw_opts)
+
+    case raw_opts[:cloud_provider] do
+      :aws ->
+        opts[:cert] || raise "AWS IoT requires a :device_cert."
+        opts[:key] || raise "AWS IoT requires a :device_key."
+        raw_opts[:signer_cert] || raise "AWS IoT requires a :signer_cert."
+        Keyword.put(opts, :cacerts, [raw_opts[:signer_cert] | opts[:cacerts]])
+
+      :gcp ->
+        opts
+    end
+  end
+
+  defp default_and_map_and_filter_server_opts(opts) do
+    default_opts = %{
+      aws: [
+        alpn_advertised_protocols: ["x-amzn-mqtt-ca"],
+        cacerts: [],
+        server_name_indication: "*.iot.us-east-1.amazonaws.com"
+      ],
+      gcp: [],
+      shared: [
+        partial_chain: &CloudPubSub.SSL.partial_chain(opts[:cloud_provider], &1),
+        verify: :verify_peer,
+        versions: [:"tlsv1.2"]
+      ]
+    }
+
+    opts
+    |> Enum.into(default_opts[:shared] ++ default_opts[opts[:cloud_provider]], fn
+      {:ca_certs, cacerts} -> {:cacerts, cacerts}
+      {:device_cert, cert} -> {:cert, cert}
+      {:device_key, key} -> {:key, key}
+      kvp -> kvp
+    end)
+    |> Keyword.take([:cacerts, :host, :partial_chain, :port, :verify, :versions, :cert, :key])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule CloudPubSub.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:mix_test_watch, "~> 1.0"},
       {:tortoise, "~> 0.9"},
       {:x509, "~> 0.8"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
+  "file_system": {:hex, :file_system, "0.2.9", "545b9c9d502e8bfa71a5315fac2a923bd060fd9acb797fe6595f54b0f975fd32", [:mix], [], "hexpm", "3cf87a377fe1d93043adeec4889feacf594957226b4f19d5897096d6f61345d8"},
   "gen_state_machine": {:hex, :gen_state_machine, "2.0.5", "9ac15ec6e66acac994cc442dcc2c6f9796cf380ec4b08267223014be1c728a95", [:mix], [], "hexpm", "5cacd405e72b2609a7e1f891bddb80c53d0b3b7b0036d1648e7382ca108c41c8"},
+  "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "47ac558d8b06f684773972c6d04fcc15590abdb97aeb7666da19fcbfdc441a07"},
   "tortoise": {:hex, :tortoise, "0.9.4", "3bca5f4475f80a5bd45aab644ddb3364dd0956b67f4202dcef6ed20e045ea3a6", [:mix], [{:gen_state_machine, "~> 2.0", [hex: :gen_state_machine, repo: "hexpm", optional: false]}], "hexpm", "d5c00d7c2329016376181e19f18116a10fc65691bd96b08e5b726ca050d10094"},
   "x509": {:hex, :x509, "0.8.0", "b286b9dbb32801f76f48bdea476304d280c64ce172ea330c23d8df7ea9e75ce6", [:mix], [], "hexpm", "8aafaafdcafb1ea9f06bfc32c3b03ccc66f087e0faf36ef94c0195bb7a04157e"},
 }

--- a/test/cloud_pub_sub/adapters/tortoise/ssl_test.exs
+++ b/test/cloud_pub_sub/adapters/tortoise/ssl_test.exs
@@ -1,0 +1,69 @@
+defmodule CloudPubSub.Adapters.Tortoise.SSLTest do
+  use ExUnit.Case
+  alias CloudPubSub.Adapters.Tortoise.SSL
+
+  describe "resolve_connection_opts/1" do
+    test "AWS" do
+      opts = [
+        cloud_provider: :aws,
+        signer_cert: "der-binary-1",
+        device_cert: "der-binary-2",
+        device_key: "device-key",
+        client_id: "device-id",
+        host: "aws-ats-endpoint",
+        port: 123,
+        subscriptions: ["sub"]
+      ]
+
+      expected_except_server = %{
+        client_id: "device-id",
+        cloud_provider: :aws,
+        handler: nil,
+        subscriptions: ["sub"]
+      }
+
+      actual = SSL.resolve_connection_opts(opts)
+      assert expected_except_server == Map.delete(actual, :server)
+      assert {Tortoise.Transport.SSL, actual_server_opts} = actual.server
+      assert is_function(actual_server_opts[:partial_chain])
+      assert :verify_peer == actual_server_opts[:verify]
+      assert [:"tlsv1.2"] == actual_server_opts[:versions]
+      assert "aws-ats-endpoint" == actual_server_opts[:host]
+      assert ["der-binary-1"] == actual_server_opts[:cacerts]
+      assert "der-binary-2" == actual_server_opts[:cert]
+      assert "device-key" == actual_server_opts[:key]
+      assert 123 == actual_server_opts[:port]
+    end
+
+    test "GCP" do
+      opts = [
+        client_id:
+          "projects/project-name/locations/us-central1/registries/registry-name/devices/device-id",
+        cloud_provider: :gcp,
+        host: "mqtt.googleapis.com",
+        password: "jwt",
+        port: 123,
+        subscriptions: ["sub"],
+        username: "unused"
+      ]
+
+      expected_except_server = %{
+        client_id:
+          "projects/project-name/locations/us-central1/registries/registry-name/devices/device-id",
+        cloud_provider: :gcp,
+        handler: nil,
+        password: "jwt",
+        subscriptions: ["sub"]
+      }
+
+      actual = SSL.resolve_connection_opts(opts)
+      assert expected_except_server == Map.delete(actual, :server)
+      assert {Tortoise.Transport.SSL, actual_server_opts} = actual.server
+      assert is_function(actual_server_opts[:partial_chain])
+      assert :verify_peer == actual_server_opts[:verify]
+      assert [:"tlsv1.2"] == actual_server_opts[:versions]
+      assert "mqtt.googleapis.com" == actual_server_opts[:host]
+      assert 123 == actual_server_opts[:port]
+    end
+  end
+end


### PR DESCRIPTION
Why
---

- Prior to this commit, when configuring for GCP, one could provide no
  cert option, but CloudPubSub would still errantly crash finding a cert
  option with a value of nil that the library itself introduced.

How
---

- Rather than always setting cacerts, cert, and key in server_opts for
  all cloud providers as a side effect of transforming their field name,
  instead, only map their field name if it was actually set on opts
  already.
- Make options resolution more explicit in general.
- Add :mix_test_watch.
- Add tests for resolving AWS and GCP options.