### PR TITLE
Allow casting of publish

### DIFF
--- a/lib/cloud_pub_sub.ex
+++ b/lib/cloud_pub_sub.ex
@@ -34,6 +34,8 @@ defmodule CloudPubSub do
   defdelegate connected?(), to: CloudPubSub.Adapter
 
   defdelegate publish(topic, payload, opts), to: CloudPubSub.Adapter
+  defdelegate publish_cast(topic, payload, opts), to: CloudPubSub.Adapter
+
   defdelegate subscribe(topic, opts \\ []), to: CloudPubSub.Adapter
 
   @doc """

--- a/lib/cloud_pub_sub/adapter.ex
+++ b/lib/cloud_pub_sub/adapter.ex
@@ -44,6 +44,11 @@ defmodule CloudPubSub.Adapter do
     {:reply, ret, Map.put(state, :adapter_state, adapter_state)}
   end
 
+  def handle_cast({:publish, topic, payload, opts}, _from, state) do
+    {_ret, adapter_state} = state.adapter.publish(topic, payload, opts, state.adapter_state)
+    {:noreply, Map.put(state, :adapter_state, adapter_state)}
+  end
+
   def handle_call({:subscribe, topic, opts}, _from, state) do
     {ret, adapter_state} = state.adapter.subscribe(topic, opts, state.adapter_state)
     {:reply, ret, Map.put(state, :adapter_state, adapter_state)}
@@ -68,6 +73,15 @@ defmodule CloudPubSub.Adapter do
   """
   def publish(topic, payload, opts) do
     GenServer.call(__MODULE__, {:publish, topic, payload, opts})
+  end
+
+  @doc """
+  Attempt to publish to AWS IoT Core.
+  This function is a cast, so usage is asynchronous to the caller and does
+  not return a response. (Not useful for qos > 0)
+  """
+  def publish_cast(topic, payload, opts) do
+    GenServer.cast(__MODULE__, {:publish, topic, payload, opts})
   end
 
   @doc """

--- a/lib/cloud_pub_sub/adapter.ex
+++ b/lib/cloud_pub_sub/adapter.ex
@@ -44,7 +44,7 @@ defmodule CloudPubSub.Adapter do
     {:reply, ret, Map.put(state, :adapter_state, adapter_state)}
   end
 
-  def handle_cast({:publish, topic, payload, opts}, _from, state) do
+  def handle_cast({:publish, topic, payload, opts}, state) do
     {_ret, adapter_state} = state.adapter.publish(topic, payload, opts, state.adapter_state)
     {:noreply, Map.put(state, :adapter_state, adapter_state)}
   end

--- a/test/aws_iot_test.exs
+++ b/test/aws_iot_test.exs
@@ -1,5 +1,4 @@
 defmodule CloudPubSubTest do
   use ExUnit.Case
   doctest CloudPubSub
-
 end


### PR DESCRIPTION
WHY
----
Sometimes a handler needs to send a response payload to AWS

HOW
----
A cast allows the user to send a publish to PubSub and then return from the handler. This prevents deadlocks