### PR TITLE
Fix GCP connectivity

### DIFF
--- a/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
@@ -38,10 +38,9 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
           )
 
         :gcp ->
-          Keyword.merge(
-            [],
-            server_opts
-          )
+          server_opts
+          |> Keyword.delete(:cert)
+          |> Keyword.delete(:key)
       end
 
     server = {Tortoise.Transport.SSL, server_opts}


### PR DESCRIPTION
## Why

When attempting to connect to GCP, the connection is terminated immediately due to missing values for `:cert` and `:key`. This is a regression from 4e1f5fe.

```text
17:14:20.005 [error] GenServer {Tortoise.Registry, {Tortoise.Connection, "<client-id>"}} terminating
** (stop) {:options, {:cert, nil}}
```

## How

When using GCP as the cloud provider, delete the `:cert` and `:key` options that were added for AWS before starting Tortoise.