### PR TITLE
Update AWS connection options

### DIFF
--- a/lib/cloud_pub_sub/adapter.ex
+++ b/lib/cloud_pub_sub/adapter.ex
@@ -28,6 +28,9 @@ defmodule CloudPubSub.Adapter do
           ca_certs: [String.t()],
           signer_cert: String.t()
         ]
+
+  @aws_sni "*.iot.us-east-1.amazonaws.com"
+  @gcp_sni nil
   @doc """
   Return whether there is an active connection to AWS IoT Core.
   """
@@ -120,5 +123,9 @@ defmodule CloudPubSub.Adapter do
     |> Keyword.put_new(:port, 443)
     |> Keyword.put_new(:ca_certs, CloudPubSub.ca_certs(opts[:cloud_provider]))
     |> Keyword.put_new(:subscriptions, [])
+    |> Keyword.put_new(:server_name_indication, sni(opts[:cloud_provider]))
   end
+
+  defp sni(:aws), do: @aws_sni
+  defp sni(:gcp), do: @gcp_sni
 end

--- a/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
+++ b/lib/cloud_pub_sub/adapters/tortoise/ssl.ex
@@ -19,6 +19,7 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
       cacerts: opts[:ca_certs],
       host: opts[:host],
       partial_chain: &CloudPubSub.SSL.partial_chain(opts[:cloud_provider], &1),
+      customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)],
       port: opts[:port],
       verify: :verify_peer,
       versions: [:"tlsv1.2"],
@@ -31,7 +32,7 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
         :aws ->
           Keyword.merge(
             [
-              server_name_indication: "*.iot.us-east-1.amazonaws.com",
+              server_name_indication: opts[:server_name_indication],
               alpn_advertised_protocols: ["x-amzn-mqtt-ca"]
             ],
             server_opts
@@ -41,6 +42,7 @@ defmodule CloudPubSub.Adapters.Tortoise.SSL do
           server_opts
           |> Keyword.delete(:cert)
           |> Keyword.delete(:key)
+          |> Keyword.delete(:server_name_indication)
       end
 
     server = {Tortoise.Transport.SSL, server_opts}

--- a/test/cloud_pub_sub/adapter_test.exs
+++ b/test/cloud_pub_sub/adapter_test.exs
@@ -1,0 +1,55 @@
+defmodule CloudPubSub.Adapter.Mock do
+  @behaviour CloudPubSub.Adapter
+
+  @impl CloudPubSub.Adapter
+  def connected?(state), do: {false, state}
+
+  @impl CloudPubSub.Adapter
+  def publish(_topic, _payload, opts, state), do: {opts, state}
+
+  @impl CloudPubSub.Adapter
+  def subscribe(_topic, _opts, state), do: {false, state}
+
+  def init(opts) do
+    {:ok, opts}
+  end
+end
+
+defmodule CloudPubSub.AdapterTest do
+  use ExUnit.Case
+  alias CloudPubSub.Adapter
+
+  setup do
+    Application.put_env(:cloud_pub_sub, :adapter, CloudPubSub.Adapter.Mock)
+  end
+
+  describe "init/1" do
+    test "adds a default value for sni" do
+      opts = [
+        client_id: "test",
+        cloud_provider: :aws,
+        host: "test"
+      ]
+
+      {:ok, %{adapter_state: adapter_state}} = Adapter.init(opts)
+      assert Keyword.has_key?(adapter_state, :server_name_indication)
+    end
+
+    test "allows override for sni" do
+      opts = [
+        client_id: "test",
+        cloud_provider: :aws,
+        host: "test"
+      ]
+
+      {:ok, %{adapter_state: default_opt}} = Adapter.init(opts)
+
+      {:ok, %{adapter_state: custom_opt}} =
+        opts
+        |> Keyword.merge(server_name_indication: "test")
+        |> Adapter.init()
+
+      refute custom_opt[:server_name_indication] == default_opt[:server_name_indication]
+    end
+  end
+end


### PR DESCRIPTION
Why
---

- I was not able to connect ot AWS Iot Core
- SNI is wonky as a wildcard
- erlang's SSL lib doesn't handle wildcard's well for hostname checking

How
---

- Update the default opts to supply an SNI option
- Ensure the default SNI option can be overwritten by user config
- Add the [customize_hostname_check](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl.html) option to the SSL server
- Remove SNI from GCP opts to retain current behavior
- Add very simple test for SNI config

Notes
------------

- Testing is very simple, will need refactors to go much further
- I haven't tested the `customize_hostname_check` on an older/legacy AWS connection. I'm not sure if there are any risks there or not.